### PR TITLE
add config support for button behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,22 @@ To change default keys, set the key value you want to modify to your desired key
 	Ctrl + Shift + Down              -> Move down through scrollback by line
 	Ctrl + Shift + [F1-F6]           -> Select the colorset for the current tab
 
-You can also increase and decrease the font size in the GTK standard way (not configurable):
+You can also increase and decrease the font size in the GTK standard way:
  
 	Ctrl + '+'                                -> Increase font size
 	Ctrl + '-'                                -> Decrease font size
 
+By default, mouse buttons are bound to the following:
+
+	Button1                          -> No action
+	Button2                          -> Paste
+	Button3                          -> Context menu
+
+Behavior can be changed with the following config settings:
+
+	copy_on_select                   -> set to true to automatically copy selected text
+	paste_button                     -> set to desired mouse button (default: 2)
+	menu_button                      -> set to desired mouse button (default: 3)
 
 ## Contributing
 Pull requests are welcome. But please, create first a bug report in [Launchpad](https://bugs.launchpad.net/sakura), particularly if you plan to make major changes, to make sure your patch will be merged into **sakura**. If you'd like to contribute with translations, use the translations framework in [Launchpad](https://translations.launchpad.net/sakura) or send [me](mailto:dabisu@gmail.com) directly the translated po file.

--- a/src/sakura.c
+++ b/src/sakura.c
@@ -277,6 +277,9 @@ static struct {
 	gint set_colorset_keys[NUM_COLORSETS];
 	VteRegex *http_vteregexp, *mail_vteregexp;
 	char *argv[3];
+	bool copy_on_select;
+	gint paste_button;
+	gint menu_button;
 } sakura;
 
 struct terminal {
@@ -333,6 +336,9 @@ struct terminal {
 #define DEFAULT_INCREASE_FONT_SIZE_KEY GDK_KEY_plus
 #define DEFAULT_DECREASE_FONT_SIZE_KEY GDK_KEY_minus
 #define DEFAULT_SCROLLABLE_TABS TRUE
+#define DEFAULT_COPY_ON_SELECT FALSE
+#define DEFAULT_PASTE_BUTTON 2
+#define DEFAULT_MENU_BUTTON 3
 
 /* make this an array instead of #defines to get a compile time
  * error instead of a runtime if NUM_COLORSETS changes */
@@ -372,6 +378,7 @@ static GQuark term_data_id = 0;
 void sakura_spawm_callback (VteTerminal *, GPid, GError, gpointer);
 /* VTE callbacks */
 static gboolean sakura_button_press (GtkWidget *, GdkEventButton *, gpointer);
+static gboolean sakura_button_release (GtkWidget *, GdkEventButton *, gpointer);
 static void     sakura_beep (GtkWidget *, void *);
 static void     sakura_increase_font (GtkWidget *, void *);
 static void     sakura_decrease_font (GtkWidget *, void *);
@@ -923,6 +930,28 @@ sakura_page_removed (GtkWidget *widget, void *data)
 /*****************/
 
 static gboolean
+sakura_button_release(GtkWidget *widget, GdkEventButton *button_event, gpointer user_data)
+{
+	struct terminal *term;
+	gint page, tag;
+
+	if (button_event->type != GDK_BUTTON_RELEASE)
+		return FALSE;
+
+	page = gtk_notebook_get_current_page(GTK_NOTEBOOK(sakura.notebook));
+	term = sakura_get_page_term(sakura, page);
+
+	if (sakura.copy_on_select
+		&& button_event->button == 1
+		&& vte_terminal_get_has_selection(VTE_TERMINAL(term->vte))) {
+		sakura_copy(NULL, NULL);
+	}
+
+	return FALSE;
+}
+
+
+static gboolean
 sakura_button_press(GtkWidget *widget, GdkEventButton *button_event, gpointer user_data)
 {
 	struct terminal *term;
@@ -947,8 +976,13 @@ sakura_button_press(GtkWidget *widget, GdkEventButton *button_event, gpointer us
 		return TRUE;
 	}
 
-	/* Right button: show the popup menu */
-	if (button_event->button == 3) {
+	/* paste button? */
+	if (button_event->button == sakura.paste_button) {
+		sakura_paste(NULL, NULL);
+	}
+
+	/* menu button? show the popup menu */
+	if (button_event->button == sakura.menu_button) {
 		GtkMenu *menu;
 		menu = GTK_MENU (widget);
 
@@ -2256,6 +2290,21 @@ sakura_init()
 	}
 	sakura.icon = g_key_file_get_string(sakura.cfg, cfg_group, "icon_file", NULL);
 
+	if (!g_key_file_has_key(sakura.cfg, cfg_group, "copy_on_select", NULL)) {
+		sakura_set_config_boolean("copy_on_select", DEFAULT_COPY_ON_SELECT);
+	}
+	sakura.copy_on_select = g_key_file_get_boolean(sakura.cfg, cfg_group, "copy_on_select", NULL);
+
+	if (!g_key_file_has_key(sakura.cfg, cfg_group, "paste_button", NULL)) {
+		sakura_set_config_integer("paste_button", DEFAULT_PASTE_BUTTON);
+	}
+	sakura.paste_button = g_key_file_get_integer(sakura.cfg, cfg_group, "paste_button", NULL);
+
+	if (!g_key_file_has_key(sakura.cfg, cfg_group, "menu_button", NULL)) {
+		sakura_set_config_integer("menu_button", DEFAULT_MENU_BUTTON);
+	}
+	sakura.menu_button = g_key_file_get_integer(sakura.cfg, cfg_group, "menu_button", NULL);
+
 	/* set default title pattern from config or NULL */
 	sakura.tab_default_title = g_key_file_get_string(sakura.cfg, cfg_group, "tab_default_title", NULL);
 
@@ -3045,6 +3094,7 @@ sakura_add_tab()
 	// TODO: Set group id to support detached tabs
 	// gtk_notebook_set_tab_detachable(GTK_NOTEBOOK(sakura.notebook), term->hbox, TRUE);
 
+	g_signal_connect_swapped(G_OBJECT(term->vte), "button-release-event", G_CALLBACK(sakura_button_release), sakura.menu);
 	sakura_set_page_term(sakura, index, term );
 
 	/* vte signals */


### PR DESCRIPTION
Three additional config settings can handle customization of button
behavior:

```
  copy_on_select - boolean - set to true to enable automatic copy when
                             selecting
  paste_button   - integer - set to desired mouse button to trigger paste
  menu_button    - integer - set to desired mouse button to trigger menu
```

The default values for each of the above correspond to the existing
behavior in sakura.

Adding these config settings allows those familiar with putty or
mintty (which use right-click-to-paste) to feel more at home with
sakura. For example:

```
copy_on_select=true
paste_button=3
menu_button=2
```