### PR TITLE
Add keybinding to open a new window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ IF (NOT GLIB_FOUND)
 	MESSAGE(FATAL_ERROR "You don't seem to have glib >= 2.40 development libraries installed...")
 ENDIF (NOT GLIB_FOUND)
 
+pkg_check_modules (GLIB REQUIRED gio-unix-2.0)
+IF (NOT GLIB_FOUND)
+	MESSAGE(FATAL_ERROR "You don't seem to have glib >= 2.40 development libraries installed...")
+ENDIF (NOT GLIB_FOUND)
+
 pkg_check_modules (GTK REQUIRED gtk+-3.0>=3.20)
 IF (NOT GTK_FOUND)
 	MESSAGE(FATAL_ERROR "You don't seem to have gtk >= 3.20 development libraries installed...")


### PR DESCRIPTION
It's great to have tabs, but in some cases, it is also good to be able to have multiple windows open. This PR adds a keybinding to open a new window. To keep things simple, this is achieved by launching a new instance of Sakura.

Note: the `sakura_new_window()` function is a bit complicated as I've tried to take care of some corner cases (passing the same command line arguments, sakura not in path, [xdg-activation](https://wayland.app/protocols/xdg-activation-v1) etc.); I'm happy to simplify this if this is too much :)
